### PR TITLE
Added shipping cost estimate method, updated `requirements.txt` to fix Crypto import

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Crypto
+pycryptodome
 gotify-handler
 parsedatetime
 python-daemon

--- a/shopgoodwill.py
+++ b/shopgoodwill.py
@@ -17,6 +17,7 @@ _SHIPPING_COST_PATTERN = re.compile(
     r"Shipping: <span id='shipping-span'>\$(\d+\.\d+) \(.*\)<\/span>"
 )
 
+
 class Shopgoodwill:
     LOGIN_PAGE_URL = "https://shopgoodwill.com/signin"
     API_ROOT = "https://buyerapi.shopgoodwill.com/api"
@@ -419,7 +420,9 @@ class Shopgoodwill:
                 ):
                     return total_listings
 
-    def get_item_shipping_estimate(self, item_id: int, zip_code: str) -> Optional[float]:
+    def get_item_shipping_estimate(
+        self, item_id: int, zip_code: str
+    ) -> Optional[float]:
         """
         Given an item id and a zip code, returns the extracted estimated
         shipping cost result.
@@ -436,13 +439,13 @@ class Shopgoodwill:
         resp = self.shopgoodwill_session.post(
             f"{Shopgoodwill.API_ROOT}/itemDetail/CalculateShipping",
             json={
-                "itemId":item_id,
-                "zipCode":zip_code,
-                "country":"US",
-                "province":None,
-                "quantity":1,
-                "clientIP":"0.0.0.0"
-            }
+                "itemId": item_id,
+                "zipCode": zip_code,
+                "country": "US",
+                "province": None,
+                "quantity": 1,
+                "clientIP": "0.0.0.0",
+            },
         )
 
         shipping_est_price = _SHIPPING_COST_PATTERN.findall(resp.text)

--- a/shopgoodwill.py
+++ b/shopgoodwill.py
@@ -4,6 +4,7 @@ import urllib.parse
 from typing import Dict, List, Optional
 from zoneinfo import ZoneInfo
 
+import re
 import requests
 from Crypto.Cipher import AES
 from Crypto.Util.Padding import pad
@@ -12,6 +13,9 @@ from requests.models import PreparedRequest, Response
 
 # TODO add pagination
 
+_SHIPPING_COST_PATTERN = re.compile(
+    r"Shipping: <span id='shipping-span'>\$(\d+\.\d+) \(.*\)<\/span>"
+)
 
 class Shopgoodwill:
     LOGIN_PAGE_URL = "https://shopgoodwill.com/signin"
@@ -414,6 +418,39 @@ class Shopgoodwill:
                     == query_res.json()["searchResults"]["itemCount"]
                 ):
                     return total_listings
+
+    def get_item_shipping_estimate(self, item_id: int, zip_code: str) -> float:
+        """
+        Given an item id and a zip code, returns the extracted estimated
+        shipping cost result.
+
+        :param item_id: A valid Shopgoodwill item id
+        :type item_id: int
+        :param zip_code: A valid US zip or zip+4 code
+        :type zip_code: str
+        :return: A float representation of the estimated shipping cost
+        extracted from the xml api response
+        :rtype: float
+        """
+
+        resp = self.shopgoodwill_session.post(
+            f"{Shopgoodwill.API_ROOT}/itemDetail/CalculateShipping",
+            json={
+                "itemId":item_id,
+                "zipCode":zip_code,
+                "country":"US",
+                "province":None,
+                "quantity":1,
+                "clientIP":"0.0.0.0"
+            }
+        )
+
+        shipping_est_price = _SHIPPING_COST_PATTERN.findall(resp.text)
+        if len(shipping_est_price) > 0:
+            shipping_est_price = float(shipping_est_price[0])
+        else:
+            shipping_est_price = None
+        return shipping_est_price
 
     # TODO maybe if there's any internal consistency
     def paginate_request(self, prepared_request: PreparedRequest) -> List[Dict]:

--- a/shopgoodwill.py
+++ b/shopgoodwill.py
@@ -419,7 +419,7 @@ class Shopgoodwill:
                 ):
                     return total_listings
 
-    def get_item_shipping_estimate(self, item_id: int, zip_code: str) -> float:
+    def get_item_shipping_estimate(self, item_id: int, zip_code: str) -> Optional[float]:
         """
         Given an item id and a zip code, returns the extracted estimated
         shipping cost result.


### PR DESCRIPTION
Addresses #15 and #16 

1. Adds `Shopgoodwill` method `get_item_shipping_estimate` that calls the `/itemDetail/CalculateShipping` endpoint with an `item_id` and zip code to estimate shipping cost.
This is a little dirty since that endpoint returns partial HTML from which the price has to be extracted.  No clean JSON return for this.  Keeping in theme with @scottmconway's "what they hell were they thinking" observations.

2. Updates the `requirements.txt` entry for `Crypto` with `pycryptodome` to address some import problems that come up with `pycrypto` or other choices for package fulfilling the `Crypto` need.