### PR TITLE
SGW has started using timestamps which sometimes include fractional seconds

### DIFF
--- a/bid_sniper.py
+++ b/bid_sniper.py
@@ -398,11 +398,19 @@ class BidSniper:
                 if item_id in self.scheduled_tasks:
                     continue
 
+                # SGW has been including microseconds inconsistently,
+                # and one is liable to see '2025-04-29T23:00:17.45' in
+                # the same response as '2025-05-01T22:09:00'
+                end_time = favorite_info["endTime"]
+                date_format = "%Y-%m-%dT%H:%M:%S"
+                if '.' in end_time:
+                    date_format += ".%f"
+
                 # so close but yet so far away from ISO-8601
                 # SGW simply trims the "PDT" (or PST?) off of the timestamps
                 # TODO validate that the site only uses a single timezone!
                 end_time = (
-                    datetime.datetime.fromisoformat(favorite_info["endTime"])
+                    datetime.datetime.strptime(end_time, date_format)
                     .replace(tzinfo=ZoneInfo("US/Pacific"))
                     .astimezone(ZoneInfo("Etc/UTC"))
                 )

--- a/bid_sniper.py
+++ b/bid_sniper.py
@@ -92,6 +92,8 @@ class BidSniper:
         # if set, the default note to assign favorites that don't have a note
         self.default_note = self.config["bid_sniper"].get("favorite_default_note", None)
 
+        self.date_format = "%Y-%m-%dT%H:%M:%S"
+
         # logging setup
         logging_conf = config.get("logging", dict())
         self.logger = logging.getLogger("shopgoodwill_bid_sniper")
@@ -402,8 +404,8 @@ class BidSniper:
                 # and one is liable to see '2025-04-29T23:00:17.45' in
                 # the same response as '2025-05-01T22:09:00'
                 end_time = favorite_info["endTime"]
-                date_format = "%Y-%m-%dT%H:%M:%S"
-                if '.' in end_time:
+                date_format = self.date_format
+                if "." in end_time:
                     date_format += ".%f"
 
                 # so close but yet so far away from ISO-8601


### PR DESCRIPTION
See title. This morning I started getting errors from a favorites list which contained a mix of `%H:%M:%S` and `%H:%M:%S.%f` times. Maybe they will pick one and stick with it eventually. 